### PR TITLE
Added missing function call on IIFE

### DIFF
--- a/dataTables.searchHighlight.js
+++ b/dataTables.searchHighlight.js
@@ -76,3 +76,4 @@ $(document).on( 'init.dt.dth', function (e, settings, json) {
 		}
 	}
 } );
+} )(window, document, jQuery);


### PR DESCRIPTION
Fixed issue where function call parameters were missing resulting in the following error:

dataTables.searchHighlight.js:79 Uncaught SyntaxError: Unexpected end of input
